### PR TITLE
Broader node version range

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "ts-react-toolbox": "^0.0.46"
   },
   "engines": {
-    "node": "^8.5.0"
+    "node": ">=8.5.0"
   },
   "scripts": {
     "bootstrap": "ts-react-toolbox init",


### PR DESCRIPTION
Confluence can't upgrade to latest media components because they are using node 10, and the version range in engines field doesn't allow that :) 