### PR TITLE
fix: ensure onCanPlay fires once only

### DIFF
--- a/__tests__/index.tsx
+++ b/__tests__/index.tsx
@@ -643,5 +643,52 @@ describe('VideoRenderer', () => {
       expect(onTimeChange).toHaveBeenCalledWith(10, 25);
       expect(onTimeChange).toHaveBeenCalledWith(11, 25);
     });
+
+    it("should only fire onCanPlay once if browser fires multiple", () => {
+      const onCanPlay = jest.fn();
+      const { component } = setup({
+        onCanPlay,
+      });
+
+      simulate(component, "canPlay", {
+        currentTime: 0,
+        volume: 0.5,
+        duration: 25,
+      });
+      simulate(component, "canPlay", {
+        currentTime: 0,
+        volume: 0.5,
+        duration: 25,
+      });
+
+      expect(onCanPlay).toHaveBeenCalledTimes(1);
+    });
+
+    it("should reset internal hasCanPlayTriggered check on src change", () => {
+      const onCanPlay = jest.fn();
+      const { component } = setup({
+        onCanPlay,
+      });
+
+      simulate(component, "canPlay", {
+        currentTime: 0,
+        volume: 0.5,
+        duration: 25,
+      });
+
+      expect(onCanPlay).toHaveBeenCalledTimes(1);
+
+      component.setProps({
+        src: "new-video-url",
+      });
+
+      simulate(component, "canPlay", {
+        currentTime: 0,
+        volume: 0.5,
+        duration: 25,
+      });
+
+      expect(onCanPlay).toHaveBeenCalledTimes(2);
+    });
   });
 });

--- a/src/video.tsx
+++ b/src/video.tsx
@@ -85,6 +85,7 @@ export class Video extends Component<VideoProps, VideoComponentState> {
   previousTime: number = -1;
   videoRef: RefObject<HTMLVideoElement> = React.createRef<HTMLVideoElement>();
   audioRef: RefObject<HTMLAudioElement> = React.createRef<HTMLAudioElement>();
+  onCanPlayTriggered: number = 0;
 
   state: VideoComponentState = {
     isLoading: true,
@@ -170,7 +171,7 @@ export class Video extends Component<VideoProps, VideoComponentState> {
       duration: video.duration
     });
 
-    onCanPlay && onCanPlay(event);
+     ++this.onCanPlayTriggered === 1 && onCanPlay && onCanPlay(event);
   }
 
   private onPlay = () => {

--- a/src/video.tsx
+++ b/src/video.tsx
@@ -85,7 +85,7 @@ export class Video extends Component<VideoProps, VideoComponentState> {
   previousTime: number = -1;
   videoRef: RefObject<HTMLVideoElement> = React.createRef<HTMLVideoElement>();
   audioRef: RefObject<HTMLAudioElement> = React.createRef<HTMLAudioElement>();
-  onCanPlayTriggered: number = 0;
+  hasCanPlayTriggered: boolean = false;
 
   state: VideoComponentState = {
     isLoading: true,
@@ -118,6 +118,7 @@ export class Video extends Component<VideoProps, VideoComponentState> {
     const hasSrcChanged = prevProps.src !== src;
 
     if (hasSrcChanged) {
+      this.hasCanPlayTriggered = false;
       // TODO: add test to cover this case
       if (status === 'playing') {
         this.play();
@@ -171,7 +172,11 @@ export class Video extends Component<VideoProps, VideoComponentState> {
       duration: video.duration
     });
 
-     ++this.onCanPlayTriggered === 1 && onCanPlay && onCanPlay(event);
+    if (!this.hasCanPlayTriggered) {
+      // protect against browser firing this event multiple times
+      this.hasCanPlayTriggered = true;
+      onCanPlay && onCanPlay(event);
+    }
   }
 
   private onPlay = () => {


### PR DESCRIPTION
Noticed while cleaning up media-viewer analytics that `CustomVideoPlayer` was firing success events twice, because I had hooked these up to the `onCanPlay`.
Appears that the video element may be firing this multiple times, so I've added a very simple check to only fire once to consumer.