### PR TITLE
Feature: added support for video text tracks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,5 +57,8 @@ typings/
 # dotenv environment variables file
 .env
 
+# VSCode
+.vscode
+
 publish_dist
 dist

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,5 @@
+{
+  "printWidth": 120,
+  "singleQuote": true,
+  "trailingComma": "es5"
+}

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # react-video-renderer [![Build Status](https://travis-ci.org/zzarcon/react-video-renderer.svg?branch=master)](https://travis-ci.org/zzarcon/react-video-renderer)
+
 > Build custom video players effortless
 
 * Render props, get all video state passed down as props.
@@ -8,17 +9,17 @@
 * Dependency free, [<2KB size](https://bundlephobia.com/result?p=react-video-renderer)
 * Cross-browser support, no more browser hacks.
 
-# Demo 🎩
+## Demo 🎩
 
 [https://zzarcon.github.io/react-video-renderer](https://zzarcon.github.io/react-video-renderer)
 
-# Installation 🚀
+## Installation 🚀
 
-```
-$ yarn add react-video-renderer
+```bash
+yarn add react-video-renderer
 ```
 
-# Usage ⛏
+## Usage ⛏
 
 > Render video state and communicate user interactions up when volume or time changes.
 
@@ -45,9 +46,9 @@ import Video from 'react-video-renderer';
   <br><br>
 </div>
 
-# Api 💅
+## Api 💅
 
-**props**
+### Props
 
 ```typescript
 interface Props {
@@ -56,21 +57,23 @@ interface Props {
   controls?: boolean;
   autoPlay?: boolean;
   preload?: string;
+  textTracks?: VideoTextTracks;
 }
 ```
 
-**render method**
+### Render method
 
 ```typescript
-type RenderCallback = (videoElement: ReactNode, state: VideoState, actions: VideoActions) => ReactNode;
+type RenderCallback = (reactElement: ReactElement<HTMLMediaElement>, state: VideoState, actions: VideoActions, ref: React.RefObject<HTMLMediaElement>) => ReactNode;
 ```
 
-**state**
+### State
 
 ```typescript
 interface VideoState {
   status: 'playing' | 'paused' | 'errored';
   currentTime: number;
+  currentActiveCues: (kind: VideoTextTrackKind, lang: string) => TextTrackCueList | null | undefined;
   volume: number;
   duration: number;
   buffered: number;
@@ -80,7 +83,7 @@ interface VideoState {
 }
 ```
 
-**actions**
+### Actions
 
 ```typescript
 interface VideoActions {
@@ -95,9 +98,9 @@ interface VideoActions {
 }
 ```
 
-# Error handling 💥
+## Error handling 💥
 
-> this is all you need to detect video errors 
+> this is all you need to detect video errors
 
 ```jsx
 <Video src="some-error-video.mov">
@@ -119,12 +122,12 @@ interface VideoActions {
 </Video>
 ```
 
-# Loading state ✨
+## Loading state ✨
 
 > you can still interact with the player regardless if the video is loading or not
 
 ```jsx
-<Video src="me-video.mp4">
+<Video src="my-video.mp4">
   {(video, state, actions) => {
     const loadingComponent = state.isLoading ? 'loading...' : undefined;
 
@@ -140,6 +143,46 @@ interface VideoActions {
 </Video>
 ```
 
-# Author 🧔
+## Video text tracks 🚂
+
+> HTML5 [text tracks](https://html.spec.whatwg.org/multipage/media.html#the-track-element) support for videos.
+>
+> subtitles can be rendered natively, or they can be rendered using `VideoState.currentActiveCues` property:
+
+```jsx
+<Video 
+  src="my-video.mp4"
+  textTracks={{
+    'subtitles': {
+      selectedTrack: 0,
+      tracks: [
+        { src: 'subtitles-en.vtt', lang: 'en', label: 'Subtitles (english)' },
+        { src: 'subtitles-es.vtt', lang: 'es', label: 'Subtitles (spanish)' },
+      ]
+    }
+  }}
+>
+  {(video, state, actions) => {
+    const cues = state.currentActiveCues('subtitles', 'en');
+    const subtitles =
+      cue && cue.length > 0 ? (
+        <div>
+          {Array.prototype.map.call(currentEnglishSubtitlesCues, (cue, i) => <span key={i}>{cue.text}</span>)}
+        </div>
+      ) : undefined;
+
+    return (
+      <div>
+        {video}
+        {subtitles}
+        <button onClick={actions.play}>Play</button>
+        <button onClick={actions.pause}>Pause</button>
+      </div>
+    )
+  }}
+</Video>
+```
+
+## Author 🧔
 
 [@zzarcon](https://twitter.com/zzarcon)

--- a/__tests__/index.tsx
+++ b/__tests__/index.tsx
@@ -1,11 +1,6 @@
 import * as React from 'react';
 import { mount, ReactWrapper } from 'enzyme';
-import Video, {
-  VideoProps,
-  RenderCallback,
-  VideoState,
-  VideoComponentState, SourceElement
-} from '../src';
+import Video, { VideoProps, RenderCallback, VideoState, VideoComponentState, SourceElement } from '../src';
 
 describe('VideoRenderer', () => {
   const setup = (props?: Partial<VideoProps>) => {
@@ -14,54 +9,65 @@ describe('VideoRenderer', () => {
       return video;
     }) as jest.Mock<ReturnType<RenderCallback>, Parameters<RenderCallback>>;
 
-    const component = mount<Video, VideoProps, VideoComponentState>((
+    const component = mount<Video, VideoProps, VideoComponentState>(
       <Video src={src} {...props}>
         {children}
       </Video>
-    ));
+    );
     const videoActions = children.mock.calls[0][2];
 
     return {
       component,
       children,
-      videoActions
+      videoActions,
     };
   };
 
-  const simulate = (component: ReactWrapper<VideoProps, VideoComponentState, Video>, event: string, target: any = {}, sourceType: 'video' | 'audio' = 'video') => {
+  const simulate = (
+    component: ReactWrapper<VideoProps, VideoComponentState, Video>,
+    event: string,
+    target: any = {},
+    sourceType: 'video' | 'audio' = 'video'
+  ) => {
     component.find(sourceType).simulate(event, {
-      target
+      target,
     });
-  }
+  };
 
   describe('video element', () => {
     it('should create a video element with the right properties', () => {
       const { children: defaultChildren } = setup();
 
-      expect(defaultChildren.mock.calls[0][0].props).toEqual(expect.objectContaining({
-        src: 'video-url',
-        preload: 'metadata',
-        autoPlay: false,
-        controls: false
-      }));
+      expect(defaultChildren.mock.calls[0][0].props).toEqual(
+        expect.objectContaining({
+          src: 'video-url',
+          preload: 'metadata',
+          autoPlay: false,
+          controls: false,
+        })
+      );
 
       const { children: customChildren } = setup({
         src: 'some-src',
         preload: 'none',
         autoPlay: true,
-        controls: true
+        controls: true,
       });
 
-      expect(customChildren.mock.calls[0][0].props).toEqual(expect.objectContaining({
-        src: 'some-src',
-        preload: 'none',
-        autoPlay: true,
-        controls: true
-      }));
+      expect(customChildren.mock.calls[0][0].props).toEqual(
+        expect.objectContaining({
+          src: 'some-src',
+          preload: 'none',
+          autoPlay: true,
+          controls: true,
+        })
+      );
 
-      expect(customChildren.mock.calls[0][3].current).toEqual(expect.objectContaining<Partial<SourceElement>>({
-        currentTime: 0,
-      }));
+      expect(customChildren.mock.calls[0][3].current).toEqual(
+        expect.objectContaining<Partial<SourceElement>>({
+          currentTime: 0,
+        })
+      );
     });
 
     it('should play new src at the current time when src changes and video is not paused', () => {
@@ -73,11 +79,11 @@ describe('VideoRenderer', () => {
 
       simulate(component, 'timeUpdate', {
         currentTime: 10,
-        buffered: {}
+        buffered: {},
       });
       simulate(component, 'play');
       component.setProps({
-        src: 'new-src'
+        src: 'new-src',
       });
       expect(instance['play']).toHaveBeenCalledTimes(1);
       expect(instance['navigate']).toBeCalledWith(10);
@@ -95,9 +101,7 @@ describe('VideoRenderer', () => {
       expect(videoElement.currentTime).toEqual(10);
     });
 
-    xit('should return the same video element regardless of re-renders', () => {
-
-    });
+    xit('should return the same video element regardless of re-renders', () => {});
   });
 
   describe('state', () => {
@@ -105,12 +109,13 @@ describe('VideoRenderer', () => {
       const { children } = setup();
       expect(children.mock.calls[0][1]).toEqual({
         currentTime: 0,
+        currentActiveCues: expect.any(Function),
         volume: 1,
         status: 'paused',
         isMuted: false,
         isLoading: true,
         duration: 0,
-        buffered: 0
+        buffered: 0,
       });
     });
 
@@ -118,32 +123,39 @@ describe('VideoRenderer', () => {
       const { children } = setup({ sourceType: 'audio' });
       expect(children.mock.calls[0][1]).toEqual({
         currentTime: 0,
+        currentActiveCues: expect.any(Function),
         volume: 1,
         status: 'paused',
         isMuted: false,
         isLoading: true,
         duration: 0,
-        buffered: 0
+        buffered: 0,
       });
     });
 
     it('should return correct state when audio is ready to play', () => {
       const { component, children } = setup({ sourceType: 'audio' });
 
-      simulate(component, 'canPlay', {
-        currentTime: 1,
-        volume: 0.5,
-        duration: 25
-      }, 'audio');
+      simulate(
+        component,
+        'canPlay',
+        {
+          currentTime: 1,
+          volume: 0.5,
+          duration: 25,
+        },
+        'audio'
+      );
 
       expect(children.mock.calls[1][1]).toEqual({
         currentTime: 1,
+        currentActiveCues: expect.any(Function),
         volume: 0.5,
         status: 'paused',
         isMuted: false,
         isLoading: false,
         duration: 25,
-        buffered: 0
+        buffered: 0,
       });
     });
 
@@ -153,17 +165,18 @@ describe('VideoRenderer', () => {
       simulate(component, 'canPlay', {
         currentTime: 1,
         volume: 0.5,
-        duration: 25
+        duration: 25,
       });
 
       expect(children.mock.calls[1][1]).toEqual({
         currentTime: 1,
+        currentActiveCues: expect.any(Function),
         volume: 0.5,
         status: 'paused',
         isMuted: false,
         isLoading: false,
         duration: 25,
-        buffered: 0
+        buffered: 0,
       });
     });
 
@@ -171,99 +184,120 @@ describe('VideoRenderer', () => {
       const { component, children } = setup();
       simulate(component, 'timeUpdate', {
         currentTime: 1,
-        buffered: {}
+        buffered: {},
       });
 
       expect(children.mock.calls[1][1]).toEqual({
         currentTime: 1,
+        currentActiveCues: expect.any(Function),
         volume: 1,
         status: 'paused',
         isMuted: false,
         isLoading: true,
         duration: 0,
-        buffered: 0
+        buffered: 0,
       });
     });
 
     it('should return the current time whenever time changes for audio', () => {
       const { component, children } = setup({ sourceType: 'audio' });
-      simulate(component, 'timeUpdate', {
-        currentTime: 1,
-        buffered: {}
-      }, 'audio');
+      simulate(
+        component,
+        'timeUpdate',
+        {
+          currentTime: 1,
+          buffered: {},
+        },
+        'audio'
+      );
 
       expect(children.mock.calls[1][1]).toEqual({
         currentTime: 1,
+        currentActiveCues: expect.any(Function),
         volume: 1,
         status: 'paused',
         isMuted: false,
         isLoading: true,
         duration: 0,
-        buffered: 0
+        buffered: 0,
       });
     });
 
     it('should return volume value on change', () => {
       const { component, children } = setup();
       simulate(component, 'volumeChange', {
-        volume: 10
+        volume: 10,
       });
       expect(children.mock.calls[1][1]).toEqual({
         currentTime: 0,
+        currentActiveCues: expect.any(Function),
         volume: 10,
         status: 'paused',
         duration: 0,
         buffered: 0,
         isMuted: false,
-        isLoading: true
+        isLoading: true,
       });
     });
 
     it('should return volume value on change for audio', () => {
       const { component, children } = setup({ sourceType: 'audio' });
-      simulate(component, 'volumeChange', {
-        volume: 10
-      }, 'audio');
+      simulate(
+        component,
+        'volumeChange',
+        {
+          volume: 10,
+        },
+        'audio'
+      );
       expect(children.mock.calls[1][1]).toEqual({
         currentTime: 0,
+        currentActiveCues: expect.any(Function),
         volume: 10,
         status: 'paused',
         duration: 0,
         buffered: 0,
         isMuted: false,
-        isLoading: true
+        isLoading: true,
       });
     });
 
     it('should reset duration when video duration changes', () => {
       const { component, children } = setup();
       simulate(component, 'durationChange', {
-        duration: 10
+        duration: 10,
       });
       expect(children.mock.calls[1][1]).toEqual({
         currentTime: 0,
+        currentActiveCues: expect.any(Function),
         volume: 1,
         isMuted: false,
         isLoading: true,
         status: 'paused',
         duration: 10,
-        buffered: 0
+        buffered: 0,
       });
     });
 
     it('should reset duration when audio duration changes', () => {
       const { component, children } = setup({ sourceType: 'audio' });
-      simulate(component, 'durationChange', {
-        duration: 10
-      }, 'audio');
+      simulate(
+        component,
+        'durationChange',
+        {
+          duration: 10,
+        },
+        'audio'
+      );
       expect(children.mock.calls[1][1]).toEqual({
         currentTime: 0,
+        currentActiveCues: expect.any(Function),
         volume: 1,
         isMuted: false,
         isLoading: true,
         status: 'paused',
         duration: 10,
-        buffered: 0
+        buffered: 0,
       });
     });
 
@@ -294,66 +328,81 @@ describe('VideoRenderer', () => {
 
       simulate(component, 'canPlay', {
         currentTime: 1,
+        currentActiveCues: expect.any(Function),
         volume: 0,
-        duration: 2
+        duration: 2,
       });
 
       expect(children.mock.calls[1][1]).toEqual({
         currentTime: 1,
+        currentActiveCues: expect.any(Function),
         volume: 0,
         isMuted: true,
         isLoading: false,
         status: 'paused',
         duration: 2,
-        buffered: 0
+        buffered: 0,
       });
 
       simulate(component, 'volumeChange', {
-        volume: 0.1
+        volume: 0.1,
       });
 
       expect(children.mock.calls[2][1]).toEqual({
         currentTime: 1,
+        currentActiveCues: expect.any(Function),
         volume: 0.1,
         isMuted: false,
         isLoading: false,
         status: 'paused',
         duration: 2,
-        buffered: 0
+        buffered: 0,
       });
     });
 
     it('should return right value for isMuted state for audio', () => {
       const { component, children } = setup({ sourceType: 'audio' });
 
-      simulate(component, 'canPlay', {
-        currentTime: 1,
-        volume: 0,
-        duration: 2
-      }, 'audio');
+      simulate(
+        component,
+        'canPlay',
+        {
+          currentTime: 1,
+          volume: 0,
+          duration: 2,
+        },
+        'audio'
+      );
 
       expect(children.mock.calls[1][1]).toEqual({
         currentTime: 1,
+        currentActiveCues: expect.any(Function),
         volume: 0,
         isMuted: true,
         isLoading: false,
         status: 'paused',
         duration: 2,
-        buffered: 0
+        buffered: 0,
       });
 
-      simulate(component, 'volumeChange', {
-        volume: 0.1
-      }, 'audio');
+      simulate(
+        component,
+        'volumeChange',
+        {
+          volume: 0.1,
+        },
+        'audio'
+      );
 
       expect(children.mock.calls[2][1]).toEqual({
         currentTime: 1,
+        currentActiveCues: expect.any(Function),
         volume: 0.1,
         isMuted: false,
         isLoading: false,
         status: 'paused',
         duration: 2,
-        buffered: 0
+        buffered: 0,
       });
     });
 
@@ -377,7 +426,6 @@ describe('VideoRenderer', () => {
   });
 
   describe('actions', () => {
-
     it('should set video current time to passed time when navigate is called', () => {
       const { children, videoActions } = setup();
 
@@ -390,7 +438,7 @@ describe('VideoRenderer', () => {
         expect.anything(),
         expect.objectContaining(expectedState),
         expect.anything(),
-        expect.anything(),
+        expect.anything()
       );
     });
 
@@ -435,7 +483,7 @@ describe('VideoRenderer', () => {
         expect.anything(),
         expect.objectContaining(expectedState),
         expect.anything(),
-        expect.anything(),
+        expect.anything()
       );
     });
 
@@ -452,7 +500,7 @@ describe('VideoRenderer', () => {
         expect.anything(),
         expect.objectContaining(expectedState),
         expect.anything(),
-        expect.anything(),
+        expect.anything()
       );
     });
 
@@ -468,7 +516,7 @@ describe('VideoRenderer', () => {
         expect.anything(),
         expect.objectContaining(expectedState),
         expect.anything(),
-        expect.anything(),
+        expect.anything()
       );
       videoActions.unmute();
       expectedState = {
@@ -478,7 +526,7 @@ describe('VideoRenderer', () => {
         expect.anything(),
         expect.objectContaining(expectedState),
         expect.anything(),
-        expect.anything(),
+        expect.anything()
       );
     });
 
@@ -489,7 +537,7 @@ describe('VideoRenderer', () => {
         return expect(videoElement).toBeDefined();
       }
       videoActions.setPlaybackSpeed(1.5);
-      expect(videoElement.playbackRate).toEqual(1.5)
+      expect(videoElement.playbackRate).toEqual(1.5);
     });
   });
 
@@ -497,38 +545,42 @@ describe('VideoRenderer', () => {
     it('should pass dom video ref to render callback', () => {
       const { children } = setup();
       expect(children.mock.calls[0][3].current).toBeInstanceOf(HTMLVideoElement);
-    })
+    });
 
     it('should pass dom audio ref to render callback', () => {
       const { children } = setup({ sourceType: 'audio' });
       expect(children.mock.calls[0][3].current).toBeInstanceOf(HTMLAudioElement);
-    })
+    });
   });
 
   describe('as audio element', () => {
     it('should create an audio element with the right properties', () => {
       const { children: defaultChildren } = setup({ sourceType: 'audio' });
 
-      expect(defaultChildren.mock.calls[0][0].props).toEqual(expect.objectContaining({
-        src: 'video-url',
-        preload: 'metadata',
-        autoPlay: false,
-        controls: false
-      }));
+      expect(defaultChildren.mock.calls[0][0].props).toEqual(
+        expect.objectContaining({
+          src: 'video-url',
+          preload: 'metadata',
+          autoPlay: false,
+          controls: false,
+        })
+      );
 
       const { children: customChildren } = setup({
         src: 'some-src',
         preload: 'none',
         autoPlay: true,
-        controls: true
+        controls: true,
       });
 
-      expect(customChildren.mock.calls[0][0].props).toEqual(expect.objectContaining({
-        src: 'some-src',
-        preload: 'none',
-        autoPlay: true,
-        controls: true
-      }));
+      expect(customChildren.mock.calls[0][0].props).toEqual(
+        expect.objectContaining({
+          src: 'some-src',
+          preload: 'none',
+          autoPlay: true,
+          controls: true,
+        })
+      );
     });
 
     it('should play new src at the current time when src changes and audio is not paused', () => {
@@ -538,13 +590,18 @@ describe('VideoRenderer', () => {
       instance['play'] = jest.fn();
       instance['navigate'] = jest.fn();
 
-      simulate(component, 'timeUpdate', {
-        currentTime: 10,
-        buffered: {}
-      }, 'audio');
+      simulate(
+        component,
+        'timeUpdate',
+        {
+          currentTime: 10,
+          buffered: {},
+        },
+        'audio'
+      );
       simulate(component, 'play', {}, 'audio');
       component.setProps({
-        src: 'new-src'
+        src: 'new-src',
       });
       expect(instance['play']).toHaveBeenCalledTimes(1);
       expect(instance['navigate']).toBeCalledWith(10);
@@ -616,7 +673,7 @@ describe('VideoRenderer', () => {
         onTimeChange,
       });
 
-      simulate(component, "canPlay", {
+      simulate(component, 'canPlay', {
         currentTime: 0,
         volume: 0.5,
         duration: 25,
@@ -624,19 +681,19 @@ describe('VideoRenderer', () => {
 
       simulate(component, 'timeUpdate', {
         currentTime: 10.5,
-        buffered: {}
+        buffered: {},
       });
       simulate(component, 'timeUpdate', {
         currentTime: 10.6,
-        buffered: {}
+        buffered: {},
       });
       simulate(component, 'timeUpdate', {
         currentTime: 11.2,
-        buffered: {}
+        buffered: {},
       });
       simulate(component, 'timeUpdate', {
         currentTime: 11.5,
-        buffered: {}
+        buffered: {},
       });
 
       expect(onTimeChange).toHaveBeenCalledTimes(2);
@@ -644,18 +701,18 @@ describe('VideoRenderer', () => {
       expect(onTimeChange).toHaveBeenCalledWith(11, 25);
     });
 
-    it("should only fire onCanPlay once if browser fires multiple", () => {
+    it('should only fire onCanPlay once if browser fires multiple', () => {
       const onCanPlay = jest.fn();
       const { component } = setup({
         onCanPlay,
       });
 
-      simulate(component, "canPlay", {
+      simulate(component, 'canPlay', {
         currentTime: 0,
         volume: 0.5,
         duration: 25,
       });
-      simulate(component, "canPlay", {
+      simulate(component, 'canPlay', {
         currentTime: 0,
         volume: 0.5,
         duration: 25,
@@ -664,13 +721,13 @@ describe('VideoRenderer', () => {
       expect(onCanPlay).toHaveBeenCalledTimes(1);
     });
 
-    it("should reset internal hasCanPlayTriggered check on src change", () => {
+    it('should reset internal hasCanPlayTriggered check on src change', () => {
       const onCanPlay = jest.fn();
       const { component } = setup({
         onCanPlay,
       });
 
-      simulate(component, "canPlay", {
+      simulate(component, 'canPlay', {
         currentTime: 0,
         volume: 0.5,
         duration: 25,
@@ -679,10 +736,10 @@ describe('VideoRenderer', () => {
       expect(onCanPlay).toHaveBeenCalledTimes(1);
 
       component.setProps({
-        src: "new-video-url",
+        src: 'new-video-url',
       });
 
-      simulate(component, "canPlay", {
+      simulate(component, 'canPlay', {
         currentTime: 0,
         volume: 0.5,
         duration: 25,
@@ -691,4 +748,6 @@ describe('VideoRenderer', () => {
       expect(onCanPlay).toHaveBeenCalledTimes(2);
     });
   });
+
+  describe('text tracks', () => {});
 });

--- a/example/app.tsx
+++ b/example/app.tsx
@@ -8,8 +8,7 @@ import Button from '@atlaskit/button';
 import Select from '@atlaskit/single-select';
 import Spinner from '@atlaskit/spinner';
 import Corner from 'react-gh-corner';
-import Slider from '@atlaskit/field-range';
-import Video, { SetPlaybackSpeed } from '../src';
+import Video, { SetPlaybackSpeed, VideoTextTracks } from '../src';
 import {
   VideoRendererWrapper,
   SelectWrapper,
@@ -26,13 +25,20 @@ import {
   VolumeWrapper,
   SpinnerWrapper,
   BuiltWithWrapper,
-  PlaybackSpeedWrapper
+  PlaybackSpeedWrapper,
+  SubtitlesWrapper,
 } from './styled';
 import { TimeRange } from './timeRange';
 
 export interface ContentSource {
   content: string;
   value: string;
+  textTracks?: VideoTextTracks;
+}
+
+export interface PlaybackSpeedSource {
+  content: string;
+  value: number;
 }
 
 export interface AppState {
@@ -41,102 +47,138 @@ export interface AppState {
   playbackSpeed: number;
 }
 
-type ContentType = 'video' | 'audio'
+type ContentType = 'video' | 'audio';
+type ContentSourceSelect = Array<{ items: ContentSource[] }>;
+type PlaybackSpeedSourceSelect = Array<{ items: PlaybackSpeedSource[] }>;
 
 const audioSrc = 'https://upload.wikimedia.org/wikipedia/en/8/80/The_Amen_Break%2C_in_context.ogg';
 const audioSrcError = 'https://upload.wikimedia.org/';
 const hdVideoSrc = 'http://vjs.zencdn.net/v/oceans.mp4';
 const sdVideoSrc = 'http://vjs.zencdn.net/v/oceans.webm';
 const sdVideoSrc2 = 'http://www.onirikal.com/videos/mp4/battle_games.mp4';
+const vttSrc =
+  'http://gist.githubusercontent.com/samdutton/ca37f3adaf4e23679957b8083e061177/raw/e19399fbccbc069a2af4266e5120ae6bad62699a/sample.vtt';
 const errorVideoSrc = 'http://zzarcon';
-const chooseContent = [
+const chooseContent: ContentSourceSelect = [
   {
     items: [
       {
-        value: 'video', content: 'video'
+        value: 'video',
+        content: 'video',
       },
       {
-        value: 'audio', content: 'audio'
-      }
-    ]
-  }
-]
-const audioSources = [
+        value: 'audio',
+        content: 'audio',
+      },
+    ],
+  },
+];
+const audioSources: ContentSourceSelect = [
   {
     items: [
       { value: audioSrc, content: 'OGG' },
-      { value: audioSrcError, content: 'Errored' }
-    ]
-  }
-]
-const videoSources = [
+      { value: audioSrcError, content: 'Errored' },
+    ],
+  },
+];
+const videoSources: ContentSourceSelect = [
   {
     items: [
-      { value: hdVideoSrc, content: 'HD' },
-      { value: sdVideoSrc, content: 'SD' },
+      {
+        value: hdVideoSrc,
+        content: 'HD',
+        textTracks: {
+          subtitles: { selectedTrackIndex: 0, tracks: [{ src: vttSrc, lang: 'en', label: 'Subtitles (english)' }] },
+        },
+      },
+      {
+        value: sdVideoSrc,
+        content: 'SD',
+        textTracks: {
+          subtitles: { selectedTrackIndex: 0, tracks: [{ src: vttSrc, lang: 'en', label: 'Subtitles (english)' }] },
+        },
+      },
       { value: sdVideoSrc2, content: 'SD - 2' },
-      { value: errorVideoSrc, content: 'Errored' }
-    ]
-  }
+      { value: errorVideoSrc, content: 'Errored' },
+    ],
+  },
+];
+const playbackSpeeds: PlaybackSpeedSourceSelect = [
+  {
+    items: [
+      { value: 0.5, content: '0.5' },
+      { value: 0.75, content: '0.75' },
+      { value: 1, content: 'normal' },
+      { value: 1.25, content: '1.25' },
+      { value: 1.5, content: '1.5' },
+      { value: 1.75, content: '1.75' },
+      { value: 2, content: '2' },
+    ],
+  },
 ];
 
-const selectDefault = (type: ContentType) => type === 'audio' ? audioSources[0].items[0] : videoSources[0].items[0]
-export default class App extends Component <{}, AppState> {
+const selectDefaultSource = (type: ContentType) =>
+  type === 'audio' ? audioSources[0].items[0] : videoSources[0].items[0];
+
+const selectDefaultPlaybackSpeed = (playbackSpeed: number) =>
+  playbackSpeeds[0].items.find((item) => item.value === playbackSpeed);
+
+export default class App extends Component<{}, AppState> {
+  subtitlesTrackRef: React.RefObject<HTMLTrackElement> | undefined;
+
   state: AppState = {
-    currentSource: selectDefault('video'),
+    currentSource: selectDefaultSource('video'),
     sourceType: 'video',
-    playbackSpeed: 1
-  }
+    playbackSpeed: 1,
+  };
 
   onNavigate = (navigate: Function) => (value: number) => {
     navigate(value);
-  }
+  };
 
   onVolumeChange = (setVolume: Function) => (e: any) => {
     const value = e.target.value;
     setVolume(value);
-  }
+  };
 
   toggleHD = () => {
     const { currentSource } = this.state;
 
     this.setState({
-      currentSource: currentSource.value === 'HD' ? videoSources[0].items[1] : videoSources[0].items[0]
+      currentSource: currentSource.value === 'HD' ? videoSources[0].items[1] : videoSources[0].items[0],
     });
-  }
+  };
 
   onContentSelected = (e: { item: ContentSource }) => {
     this.setState({
-      currentSource: e.item
+      currentSource: e.item,
     });
-  }
+  };
 
   renderSpinner = () => {
     return (
       <SpinnerWrapper>
-        <Spinner size="xlarge"/>
+        <Spinner size="xlarge" />
       </SpinnerWrapper>
     );
-  }
+  };
 
-  switchContent = (e: { item: { value: ContentType, content: ContentType } }) => {
-    this.setState({ sourceType: e.item.value, currentSource: selectDefault(e.item.value) });
-  }
+  switchContent = (e: { item: { value: ContentType; content: ContentType } }) => {
+    this.setState({ sourceType: e.item.value, currentSource: selectDefaultSource(e.item.value) });
+  };
 
   private changePlaybackSpeed = (setPlaybackSpeed: SetPlaybackSpeed) => (playbackSpeed: number) => {
     setPlaybackSpeed(playbackSpeed);
-    this.setState({ playbackSpeed })
-  }
+    this.setState({ playbackSpeed });
+  };
 
   private getDefaultTimeLocalStorageKey() {
     const { currentSource } = this.state;
-    return `react-video-render-default-time-${currentSource.value}`
+    return `react-video-render-default-time-${currentSource.value}`;
   }
 
   private get defaultTime(): number {
-    const savedTime = localStorage.getItem(
-      this.getDefaultTimeLocalStorageKey()
-    );
+    const savedTime = localStorage.getItem(this.getDefaultTimeLocalStorageKey());
 
     if (savedTime) {
       return JSON.parse(savedTime);
@@ -146,11 +188,8 @@ export default class App extends Component <{}, AppState> {
   }
 
   private onTimeChange = (currentTime: number) => {
-    localStorage.setItem(
-      this.getDefaultTimeLocalStorageKey(),
-      JSON.stringify(currentTime),
-    );
-  }
+    localStorage.setItem(this.getDefaultTimeLocalStorageKey(), JSON.stringify(currentTime));
+  };
 
   render() {
     const { currentSource, sourceType, playbackSpeed } = this.state;
@@ -158,69 +197,83 @@ export default class App extends Component <{}, AppState> {
     return (
       <AppWrapper>
         <BuiltWithWrapper>
-          Built with <a target="_blank"
-                        href="https://github.com/zzarcon/react-video-renderer">react-video-renderer</a> 🎥
+          Built with{' '}
+          <a target="_blank" href="https://github.com/zzarcon/react-video-renderer">
+            react-video-renderer
+          </a>{' '}
+          🎥
         </BuiltWithWrapper>
-        <Corner
-          href="https://github.com/zzarcon/react-video-renderer"
-          size={100}
-        />
+        <Corner href="https://github.com/zzarcon/react-video-renderer" size={100} />
         <SelectWrapper>
           <Select
             label="Content type"
             items={chooseContent}
             onSelected={this.switchContent}
             defaultSelected={{
-              value: 'video', content: 'video'
+              value: 'video',
+              content: 'video',
             }}
           />
           <Select
             label="Content src"
             items={sourceType === 'audio' ? audioSources : videoSources}
-            defaultSelected={selectDefault(sourceType)}
+            defaultSelected={selectDefaultSource(sourceType)}
             onSelected={this.onContentSelected}
           />
         </SelectWrapper>
         <VideoRendererWrapper>
           <Video
             sourceType={sourceType}
+            crossOrigin="anonymous"
             src={currentSource.value}
+            autoPlay={true}
+            textTracks={currentSource.textTracks}
             defaultTime={this.defaultTime}
             onTimeChange={this.onTimeChange}
           >
             {(video, videoState, actions) => {
               const { status, currentTime, buffered, duration, volume, isLoading } = videoState;
               if (status === 'errored') {
-                return (
-                  <ErrorWrapper>
-                    Error
-                  </ErrorWrapper>
-                );
+                return <ErrorWrapper>Error</ErrorWrapper>;
               }
-              const button = status === 'playing' ? (
-                <Button iconBefore={<VidPauseIcon label="play"/>} onClick={actions.pause}/>
-              ) : (
-                <Button iconBefore={<VidPlayIcon label="pause"/>} onClick={actions.play}/>
-              );
+              const button =
+                status === 'playing' ? (
+                  <Button iconBefore={<VidPauseIcon label="play" />} onClick={actions.pause} />
+                ) : (
+                  <Button iconBefore={<VidPlayIcon label="pause" />} onClick={actions.play} />
+                );
               const fullScreenButton = sourceType === 'video' && (
-                <Button iconBefore={<VidFullScreenOnIcon label="fullscreen"/>}
-                        onClick={actions.requestFullscreen}/>);
-              const hdButton = sourceType === 'video' &&
-                <Button onClick={this.toggleHD}>HD</Button>;
+                <Button iconBefore={<VidFullScreenOnIcon label="fullscreen" />} onClick={actions.requestFullscreen} />
+              );
+              const hdButton = sourceType === 'video' && <Button onClick={this.toggleHD}>HD</Button>;
+
+              const playbackSpeedSelect = (
+                <PlaybackSpeedWrapper>
+                  <Select
+                    appearance="normal"
+                    droplistShouldFitContainer={true}
+                    label="Speed"
+                    position="bottom center"
+                    items={playbackSpeeds}
+                    defaultSelected={selectDefaultPlaybackSpeed(playbackSpeed)}
+                    onSelected={({ item: { value } }: any) => this.changePlaybackSpeed(actions.setPlaybackSpeed)(value)}
+                  />
+                </PlaybackSpeedWrapper>
+              );
+
+              const currentEnglishSubtitlesCues = videoState.currentActiveCues('subtitles', 'en');
+              const subtitles =
+                currentEnglishSubtitlesCues && currentEnglishSubtitlesCues.length > 0 ? (
+                  <SubtitlesWrapper>
+                    {Array.prototype.map.call(currentEnglishSubtitlesCues, (cue: any, index: number) => (
+                      <span key={index}>{cue.text}</span>
+                    ))}
+                  </SubtitlesWrapper>
+                ) : undefined;
 
               return (
                 <VideoWrapper>
                   {isLoading && this.renderSpinner()}
-                  <PlaybackSpeedWrapper>
-                    Speed: {playbackSpeed}
-                    <Slider
-                      step={0.5}
-                      min={0.5}
-                      max={2}
-                      value={playbackSpeed}
-                      onChange={this.changePlaybackSpeed(actions.setPlaybackSpeed)}
-                    />
-                  </PlaybackSpeedWrapper>
                   {video}
                   <TimebarWrapper>
                     <TimeRangeWrapper>
@@ -238,25 +291,31 @@ export default class App extends Component <{}, AppState> {
                           {Math.round(currentTime)} / {Math.round(duration)}
                         </CurrentTime>
                         <VolumeWrapper>
-                          <MutedIndicator isMuted={videoState.isMuted}/>
-                          <Button onClick={actions.toggleMute}
-                                  iconBefore={<VolumeIcon label="volume"/>}/>
-                          <input type="range" step={0.01} value={volume} max={1}
-                                 onChange={this.onVolumeChange(actions.setVolume)}/>
+                          <MutedIndicator isMuted={videoState.isMuted} />
+                          <Button onClick={actions.toggleMute} iconBefore={<VolumeIcon label="volume" />} />
+                          <input
+                            type="range"
+                            step={0.01}
+                            value={volume}
+                            max={1}
+                            onChange={this.onVolumeChange(actions.setVolume)}
+                          />
                         </VolumeWrapper>
                       </LeftControls>
                       <RightControls>
+                        {playbackSpeedSelect}
                         {hdButton}
                         {fullScreenButton}
                       </RightControls>
                     </ControlsWrapper>
                   </TimebarWrapper>
+                  {subtitles}
                 </VideoWrapper>
               );
             }}
           </Video>
         </VideoRendererWrapper>
       </AppWrapper>
-    )
+    );
   }
 }

--- a/example/styled.ts
+++ b/example/styled.ts
@@ -1,4 +1,4 @@
-import styled, {injectGlobal} from 'styled-components';
+import styled, { injectGlobal } from 'styled-components';
 
 injectGlobal`
   * {
@@ -11,13 +11,9 @@ injectGlobal`
   }
 `;
 
-export const AppWrapper = styled.div`
-  
-`;
+export const AppWrapper = styled.div``;
 
-export const Timebar = styled.progress`
-
-`;
+export const Timebar = styled.progress``;
 
 export const TimebarWrapper = styled.div`
   position: absolute;
@@ -41,9 +37,12 @@ export const MutedIndicator = styled.div`
   opacity: 0;
   pointer-events: none;
 
-  ${(props: VolumeWrapperProps) => props.isMuted ? `
+  ${(props: VolumeWrapperProps) =>
+    props.isMuted
+      ? `
     opacity: 1;
-  ` : ''}
+  `
+      : ''}
 `;
 
 export const VolumeWrapper = styled.div`
@@ -53,7 +52,7 @@ export const VolumeWrapper = styled.div`
   position: relative;
   width: 35px;
   overflow: hidden;
-  transition: width .3s ease-out; 
+  transition: width 0.3s ease-out;
   transition-delay: 1s;
 
   input {
@@ -62,11 +61,11 @@ export const VolumeWrapper = styled.div`
 
   &:hover {
     width: 165px;
-    transition: width .3s
+    transition: width 0.3s;
   }
   &:active {
     width: 165px;
-    transition: width .3s
+    transition: width 0.3s;
   }
 `;
 
@@ -86,7 +85,7 @@ export const BufferedProgress = styled.progress`
 export const TimeLine = styled.div`
   width: 100%;
   height: 3px;
-  background-color: rgba(255,255,255,.2);
+  background-color: rgba(255, 255, 255, 0.2);
   border-radius: 5px;
   position: relative;
 `;
@@ -111,14 +110,12 @@ export const Thumb = styled.div`
 `;
 
 export const BufferedTime = styled.div`
-  background-color: rgba(255,255,255,.4);
+  background-color: rgba(255, 255, 255, 0.4);
   height: inherit;
   border-radius: inherit;
 `;
 
-export const TimeRangeWrapper = styled.div`
-
-`;
+export const TimeRangeWrapper = styled.div``;
 
 export const ControlsWrapper = styled.div`
   display: flex;
@@ -156,12 +153,47 @@ export const RightControls = styled.div`
   align-items: center;
 `;
 
+export const VideoRendererWrapper = styled.div`
+  text-align: center;
+  position: relative;
+  top: 100px;
+  width: 100%;
+  overflow: hidden;
+  background: black;
+  height: calc(100vh - 200px);
+`;
+
+export const PlaybackSpeedWrapper = styled.div`
+  > div {
+    width: 135px;
+  }
+
+  label {
+    float: left;
+    margin-right: 10px;
+  }
+`;
+
 export const VideoWrapper = styled.div`
   display: flex;
+  width: 100%;
   height: 100%;
   align-items: center;
   justify-content: center;
   flex-direction: column;
+
+  video {
+    position: relative;
+    height: 100%;
+  }
+
+  video::cue,
+  video::-webkit-media-text-track-display-backdrop,
+  video::-webkit-media-text-track-display,
+  video::-webkit-media-text-track-container {
+    opacity: 0;
+    background-color: transparent !important;
+  }
 `;
 
 export const ErrorWrapper = styled.div`
@@ -171,25 +203,13 @@ export const ErrorWrapper = styled.div`
   top: 50%;
   transform: translate(-50%, -50%);
   font-size: 25px;
-`
+`;
 
 export const SelectWrapper = styled.div`
   position: absolute;
   left: 50%;
   transform: translateX(-50%);
   z-index: 1;
-`;
-
-export const VideoRendererWrapper = styled.div`
-  text-align: center;
-  position: absolute;
-  top: 50%;
-  transform: translateY(-50%);
-  width: 100%;
-  overflow: hidden;
-  background: black;
-  height: calc(100% - 135px);
-  margin-top: 17px;
 `;
 
 export const SpinnerWrapper = styled.div`
@@ -212,13 +232,19 @@ export const BuiltWithWrapper = styled.div`
   border: 1px solid #ccc;
   border-radius: 3px;
   padding: 5px;
-  
+
   a {
     color: black;
   }
 `;
 
-export const PlaybackSpeedWrapper = styled.div`
-  background: white;
-  padding-top: 80px;
+export const SubtitlesWrapper = styled.div`
+  position: absolute;
+  bottom: 120px;
+  font-size: 1.8rem;
+  font-weight: 600;
+  -webkit-text-fill-color: white;
+  -webkit-text-stroke-width: 1px;
+  -webkit-text-stroke-color: black;
+  color: white;
 `;

--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
   "license": "MIT",
   "devDependencies": {
     "@atlaskit/button": "^7.0.2",
-    "@atlaskit/field-range": "^9.0.0",
     "@atlaskit/icon": "^11.0.0",
     "@atlaskit/single-select": "^4.0.3",
     "@atlaskit/spinner": "^8.0.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,15 @@
-export {Video as default} from './video';
-export * from './video';
+export type {
+  VideoProps,
+  VideoComponentState,
+  VideoStatus,
+  VideoError,
+  VideoState,
+  NavigateFunction,
+  SetVolumeFunction,
+  SetPlaybackSpeed,
+  VideoActions,
+  RenderCallback,
+  SourceElement,
+} from './video';
+export type { VideoTextTracks, VideoTextTracksProps, VideoTextTrack, VideoTextTrackKind } from './text';
+export { Video as default } from './video';

--- a/src/text.tsx
+++ b/src/text.tsx
@@ -1,0 +1,22 @@
+export type VideoTextTracks = {
+  subtitles?: VideoTextTracksProps;
+  captions?: VideoTextTracksProps;
+  descriptions?: VideoTextTracksProps;
+  chapters?: VideoTextTracksProps;
+  metadata?: VideoTextTracksProps;
+};
+
+export type VideoTextTracksProps = {
+  selectedTrackIndex?: number;
+  tracks: VideoTextTrack[];
+};
+
+export type VideoTextTrack = {
+  src: string;
+  lang: string;
+  label: string;
+};
+
+export type VideoTextTrackKind = keyof VideoTextTracks;
+
+export const getVideoTextTrackId = (kind: VideoTextTrackKind, lang: string) => `${kind}-${lang}`;

--- a/yarn.lock
+++ b/yarn.lock
@@ -45,14 +45,6 @@
     babel-runtime "^6.26.0"
     styled-components "1.4.6 - 3"
 
-"@atlaskit/field-range@^9.0.0":
-  version "9.0.0"
-  resolved "https://registry.yarnpkg.com/@atlaskit/field-range/-/field-range-9.0.0.tgz#08a5595bc769b2793117cec63cc72a207a26a987"
-  integrity sha512-ApVzS1B+ijJTEBoV3jr0y8/t4mxVCzxurv0xVvqjpgY8zj6Tg9keftOqQcnOYxINgRZLXxb7vN4JbUWhUMFYSw==
-  dependencies:
-    "@atlaskit/theme" "^10.0.0"
-    "@babel/runtime" "^7.0.0"
-
 "@atlaskit/icon@^11.0.0", "@atlaskit/icon@^11.3.0":
   version "11.3.2"
   resolved "https://registry.yarnpkg.com/@atlaskit/icon/-/icon-11.3.2.tgz#59e3583ea4c1039f4cd61ae5cd0b19a2beb9ef9f"
@@ -126,15 +118,6 @@
     "@atlaskit/theme" "^4.0.4"
     babel-runtime "^6.26.0"
     react-transition-group "^2.2.1"
-
-"@atlaskit/theme@^10.0.0":
-  version "10.0.1"
-  resolved "https://registry.yarnpkg.com/@atlaskit/theme/-/theme-10.0.1.tgz#91c6fed6e369f154b7af2d99fbed98d9cefef6e6"
-  integrity sha512-XUor9lYlX0yTRSxd/rvaL8i2gdm0PDbOV+KhuezpuGBaS0opzseRrCnEc+OMGmpWRYHjCRyEugp6FwSSquFb8w==
-  dependencies:
-    exenv "^1.2.2"
-    prop-types "^15.5.10"
-    tslib "^1.9.3"
 
 "@atlaskit/theme@^3.2.2":
   version "3.2.2"
@@ -397,7 +380,7 @@
     core-js-pure "^3.0.0"
     regenerator-runtime "^0.13.4"
 
-"@babel/runtime@^7.0.0", "@babel/runtime@^7.10.2":
+"@babel/runtime@^7.10.2":
   version "7.11.2"
   resolved "https://packages.atlassian.com/api/npm/npm-remote/@babel/runtime/-/runtime-7.11.2.tgz#f549c13c754cc40b87644b9fa9f09a6a95fe0736"
   integrity sha1-9UnBPHVMxAuHZEufqfCaapX+BzY=
@@ -7827,7 +7810,7 @@ tsconfig-paths@^3.9.0:
     minimist "^1.2.0"
     strip-bom "^3.0.0"
 
-tslib@^1.13.0, tslib@^1.8.1, tslib@^1.9.0, tslib@^1.9.3:
+tslib@^1.13.0, tslib@^1.8.1, tslib@^1.9.0:
   version "1.13.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.13.0.tgz#c881e13cc7015894ed914862d276436fa9a47043"
   integrity sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==


### PR DESCRIPTION
(actually, as "pre-work" from my side, you will find two other changes:
- some prettier reformatting based on the provided `.prettierrc.json`
- I've refactored the example page putting the playback speed control in the controls at the bottom, and making sure that the video fits the screen. Simply because I couldn't see the subtitles correctly at first.

I had to "refresh" the example page to make it looks suitable for subtitles:
<img width="882" alt="Screen Shot 2021-04-11 at 7 26 49 pm" src="https://user-images.githubusercontent.com/209813/114298884-dff86980-9afb-11eb-8bdb-4d521b43d8e0.png">

Now regarding the video text tracks, it's all based on this HTML5 standard: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/track

The two additions are:
- passing a `textTracks` prop to list all available text tracks (subtitles, captions, metadata, ...) for all languages,
- `VideoState` gets a new property for inspecting the current active tracks

All text tracks are using this web standard: https://www.w3.org/TR/webvtt1/#introduction

Subtitles/captions can be rendered natively by the browser, but I've left the possibility for users to hide the default rendering (see our example page) and create their own React elements using the `VideoState.currentActiveCues()` function. This is particularly import for "metadata" tracks that don't render natively, and where users are asked to implement the rendering of these tracks themselves.

So with non-native english subtitles, our example  page now looks like this:

<img width="887" alt="Screen Shot 2021-04-11 at 7 33 21 pm" src="https://user-images.githubusercontent.com/209813/114299070-ca377400-9afc-11eb-88e1-334ceabca013.png">
