### PR TITLE
Add support for "picture in picture"

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,12 @@
 
 > Build custom video players effortless
 
-* Render props, get all video state passed down as props.
-* Bidirectional flow to render and update the video state in a declarative way.
-* No side effects out of the box, you just need to build the UI.
-* Actions handling: play, pause, mute, unmute, navigate, etc
-* Dependency free, [<2KB size](https://bundlephobia.com/result?p=react-video-renderer)
-* Cross-browser support, no more browser hacks.
+- Render props, get all video state passed down as props.
+- Bidirectional flow to render and update the video state in a declarative way.
+- No side effects out of the box, you just need to build the UI.
+- Actions handling: play, pause, mute, unmute, navigate, etc
+- Dependency free, [<2KB size](https://bundlephobia.com/result?p=react-video-renderer)
+- Cross-browser support, no more browser hacks.
 
 ## Demo 🎩
 
@@ -30,15 +30,18 @@ import Video from 'react-video-renderer';
   {(video, state, actions) => (
     <div>
       {video}
-      <div>{state.currentTime} / {state.duration} / {state.buffered}</div>
+      <div>
+        {state.currentTime} / {state.duration} / {state.buffered}
+      </div>
       <progress value={state.currentTime} max={state.duration} onChange={actions.navigate} />
       <progress value={state.volume} max={1} onChange={actions.setVolume} />
       <button onClick={actions.play}>Play</button>
       <button onClick={actions.pause}>Pause</button>
       <button onClick={actions.requestFullScreen}>Fullscreen</button>
+      <button onClick={actions.togglePictureInPicture}>Picture In Picture</button>
     </div>
   )}
-</Video>
+</Video>;
 ```
 
 <div align="center">
@@ -64,7 +67,12 @@ interface Props {
 ### Render method
 
 ```typescript
-type RenderCallback = (reactElement: ReactElement<HTMLMediaElement>, state: VideoState, actions: VideoActions, ref: React.RefObject<HTMLMediaElement>) => ReactNode;
+type RenderCallback = (
+  reactElement: ReactElement<HTMLMediaElement>,
+  state: VideoState,
+  actions: VideoActions,
+  ref: React.RefObject<HTMLMediaElement>
+) => ReactNode;
 ```
 
 ### State
@@ -106,18 +114,10 @@ interface VideoActions {
 <Video src="some-error-video.mov">
   {(video, state) => {
     if (state.status === 'errored') {
-      return (
-        <ErrorWrapper>
-          Error
-        </ErrorWrapper>
-      );
+      return <ErrorWrapper>Error</ErrorWrapper>;
     }
 
-    return (
-      <div>
-        {video}
-      </div>
-    )
+    return <div>{video}</div>;
   }}
 </Video>
 ```
@@ -138,7 +138,7 @@ interface VideoActions {
         <button onClick={actions.play}>Play</button>
         <button onClick={actions.pause}>Pause</button>
       </div>
-    )
+    );
   }}
 </Video>
 ```
@@ -150,16 +150,16 @@ interface VideoActions {
 > subtitles can be rendered natively, or they can be rendered using `VideoState.currentActiveCues` property:
 
 ```jsx
-<Video 
+<Video
   src="my-video.mp4"
   textTracks={{
-    'subtitles': {
+    subtitles: {
       selectedTrackIndex: 0,
       tracks: [
         { src: 'subtitles-en.vtt', lang: 'en', label: 'Subtitles (english)' },
         { src: 'subtitles-es.vtt', lang: 'es', label: 'Subtitles (spanish)' },
-      ]
-    }
+      ],
+    },
   }}
 >
   {(video, state, actions) => {
@@ -167,7 +167,9 @@ interface VideoActions {
     const subtitles =
       cue && cue.length > 0 ? (
         <div>
-          {Array.prototype.map.call(cues, (cue, i) => <span key={i}>{cue.text}</span>)}
+          {Array.prototype.map.call(cues, (cue, i) => (
+            <span key={i}>{cue.text}</span>
+          ))}
         </div>
       ) : undefined;
 
@@ -178,7 +180,7 @@ interface VideoActions {
         <button onClick={actions.play}>Play</button>
         <button onClick={actions.pause}>Pause</button>
       </div>
-    )
+    );
   }}
 </Video>
 ```

--- a/example/app.tsx
+++ b/example/app.tsx
@@ -3,6 +3,7 @@ import { Component } from 'react';
 import VidPlayIcon from '@atlaskit/icon/glyph/vid-play';
 import VidPauseIcon from '@atlaskit/icon/glyph/vid-pause';
 import VidFullScreenOnIcon from '@atlaskit/icon/glyph/vid-full-screen-on';
+import EditorTableDisplayOptionsIcon from '@atlaskit/icon/glyph/editor/table-display-options';
 import VolumeIcon from '@atlaskit/icon/glyph/hipchat/outgoing-sound';
 import Button from '@atlaskit/button';
 import Select from '@atlaskit/single-select';
@@ -245,6 +246,12 @@ export default class App extends Component<{}, AppState> {
               const fullScreenButton = sourceType === 'video' && (
                 <Button iconBefore={<VidFullScreenOnIcon label="fullscreen" />} onClick={actions.requestFullscreen} />
               );
+              const pictureInPictureButton = videoState.isPictureInPictureEnabled && sourceType === 'video' && (
+                <Button
+                  iconBefore={<EditorTableDisplayOptionsIcon label="pictureinPicture" />}
+                  onClick={actions.togglePictureInPicture}
+                />
+              );
               const hdButton = sourceType === 'video' && <Button onClick={this.toggleHD}>HD</Button>;
 
               const playbackSpeedSelect = (
@@ -306,6 +313,7 @@ export default class App extends Component<{}, AppState> {
                         {playbackSpeedSelect}
                         {hdButton}
                         {fullScreenButton}
+                        {pictureInPictureButton}
                       </RightControls>
                     </ControlsWrapper>
                   </TimebarWrapper>

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,6 +1,8 @@
 export const requestFullScreen = (element: HTMLVideoElement) => {
   const methods = ['requestFullscreen', 'webkitRequestFullscreen', 'mozRequestFullScreen', 'msRequestFullscreen'];
   const methodName = (methods as any).find((name: string) => (element as any)[name]);
-  
+
   (element as any)[methodName]();
-}
+};
+
+export const getDocument = () => ('document' in window ? document : undefined);


### PR DESCRIPTION
I tried adding unit tests, but it seems like the TS transpiler (ts-react-toolbox) has an outdated TS version and thus, it does not support PictureInPicture API.
I didn't take the time to see how to upgrade the underlying tooling. Maybe @zzarcon can have a look at that?
```
yarn test __tests__/index.tsx
yarn run v1.22.19
$ ts-react-toolbox test __tests__/index.tsx
 FAIL  __tests__/index.tsx
  ● Test suite failed to run

    src/video.tsx:262:29 - error TS2339: Property 'pictureInPictureElement' does not exist on type 'Document'.

    262     return !!getDocument()?.pictureInPictureElement;
                                    ~~~~~~~~~~~~~~~~~~~~~~~
    src/video.tsx:267:29 - error TS2339: Property 'pictureInPictureEnabled' does not exist on type 'Document'.

    267     return !!getDocument()?.pictureInPictureEnabled && sourceType === 'video';
                                    ~~~~~~~~~~~~~~~~~~~~~~~
    src/video.tsx:271:53 - error TS2339: Property 'exitPictureInPicture' does not exist on type 'Document'.

    271     this.isPictureInPictureActive && getDocument()?.exitPictureInPicture();
                                                            ~~~~~~~~~~~~~~~~~~~~
    src/video.tsx:280:36 - error TS2339: Property 'requestPictureInPicture' does not exist on type 'HTMLVideoElement'.

    280       await this.videoRef.current?.requestPictureInPicture();
                                           ~~~~~~~~~~~~~~~~~~~~~~~

Test Suites: 1 failed, 1 total
Tests:       0 total
Snapshots:   0 total
Time:        3.193 s
Ran all test suites matching /__tests__\/index.tsx/i.
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command
```